### PR TITLE
Fixed typo in challenge Redux 15

### DIFF
--- a/src/challenges/redux/Redux_15.js
+++ b/src/challenges/redux/Redux_15.js
@@ -21,7 +21,7 @@ and we write:<br><br>
 <code>newArray</code> is now a clone of <code>myArray</code>. Both still exist separately in memory. If we perform a mutation like <code>newArray.push(5)</code>,
 <code>myArray</code> will not be effected. The <code>...</code> effectively <i>spreads</i> out the values in <code>myArray</code> into a new array. To clone
 an array but add additional values in the new array you could write <code>[...myArray, 'new value']</code> which would return a new array composed of the values in
-<code>myArray</code> and the string <code>'new value'</code> as the last value. The spread syntax can be use multiple times in array composition like this, but it's important to note
+<code>myArray</code> and the string <code>'new value'</code> as the last value. The spread syntax can be used multiple times in array composition like this, but it's important to note
 that it only makes a shallow copy of the array. That is to say, it only provides immutable array operations for one-dimensional arrays.`
 
 // ---------------------------- challenge instructions ----------------------------


### PR DESCRIPTION
Before: "The spread syntax can be use multiple times"
After: "The spread syntax can be _use**d**_ multiple times"